### PR TITLE
feat(cart-api): add session-based Cart API and frontend integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 /public/bundles/
 /var/
 /vendor/
+/*.md
+!/README.md
 ###< symfony/framework-bundle ###
 
 ###> phpunit/phpunit ###

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "doctrine/doctrine-migrations-bundle": "^3.4",
         "doctrine/orm": "^3.5",
         "easycorp/easyadmin-bundle": "^4.24",
+        "nelmio/api-doc-bundle": "^5.6",
         "phpdocumentor/reflection-docblock": "^5.6",
         "phpstan/phpdoc-parser": "^2.3",
         "symfony/asset": "7.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17ba5d3f5b4fe8c1dc1856f0feb0d59e",
+    "content-hash": "b7f18faf979a5eb79997215d13afc3b7",
     "packages": [
         {
             "name": "composer/semver",
@@ -1478,6 +1478,187 @@
                 }
             ],
             "time": "2025-03-24T10:02:05+00:00"
+        },
+        {
+            "name": "nelmio/api-doc-bundle",
+            "version": "v5.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nelmio/NelmioApiDocBundle.git",
+                "reference": "9b7ece3141b74699008be55231d6907b5e8bc883"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nelmio/NelmioApiDocBundle/zipball/9b7ece3141b74699008be55231d6907b5e8bc883",
+                "reference": "9b7ece3141b74699008be55231d6907b5e8bc883",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "phpdocumentor/reflection-docblock": "^5.0",
+                "phpdocumentor/type-resolver": "^1.8.2",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "psr/container": "^1.0 || ^2.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/config": "^6.4 || ^7.1",
+                "symfony/console": "^6.4 || ^7.1",
+                "symfony/dependency-injection": "^6.4 || ^7.1",
+                "symfony/deprecation-contracts": "^2.1 || ^3",
+                "symfony/framework-bundle": "^6.4 || ^7.1",
+                "symfony/http-foundation": "^6.4 || ^7.1",
+                "symfony/http-kernel": "^6.4 || ^7.1",
+                "symfony/options-resolver": "^6.4 || ^7.1",
+                "symfony/property-info": "^6.4 || ^7.1",
+                "symfony/routing": "^6.4 || ^7.1",
+                "zircote/swagger-php": "^4.11.1 || ^5.0"
+            },
+            "conflict": {
+                "zircote/swagger-php": "4.8.7"
+            },
+            "require-dev": {
+                "api-platform/core": "^3.2",
+                "friendsofphp/php-cs-fixer": "^3.52",
+                "friendsofsymfony/rest-bundle": "^3.2.0",
+                "jms/serializer": "^3.32",
+                "jms/serializer-bundle": "^5.5",
+                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.5",
+                "phpstan/phpstan-symfony": "^1.3",
+                "phpunit/phpunit": "^10.5",
+                "symfony/asset": "^6.4 || ^7.1",
+                "symfony/browser-kit": "^6.4 || ^7.1",
+                "symfony/cache": "^6.4 || ^7.1",
+                "symfony/dom-crawler": "^6.4 || ^7.1",
+                "symfony/expression-language": "^6.4 || ^7.1",
+                "symfony/finder": "^6.4 || ^7.1",
+                "symfony/form": "^6.4 || ^7.1",
+                "symfony/phpunit-bridge": "^6.4 || ^7.1",
+                "symfony/property-access": "^6.4 || ^7.1",
+                "symfony/security-csrf": "^6.4 || ^7.1",
+                "symfony/security-http": "^6.4 || ^7.1",
+                "symfony/serializer": "^6.4 || ^7.1",
+                "symfony/stopwatch": "^6.4 || ^7.1",
+                "symfony/templating": "^6.4 || ^7.1",
+                "symfony/translation": "^6.4 || ^7.1",
+                "symfony/twig-bundle": "^6.4 || ^7.1",
+                "symfony/uid": "^6.4 || ^7.1",
+                "symfony/validator": "^6.4 || ^7.1",
+                "willdurand/hateoas-bundle": "^2.7",
+                "willdurand/negotiation": "^3.0"
+            },
+            "suggest": {
+                "api-platform/core": "For using an API oriented framework.",
+                "friendsofsymfony/rest-bundle": "For using the parameters annotations.",
+                "jms/serializer-bundle": "For describing your models.",
+                "symfony/asset": "For using the Swagger UI.",
+                "symfony/cache": "For using a PSR-6 compatible cache implementation with the API doc generator.",
+                "symfony/form": "For describing your form type models.",
+                "symfony/monolog-bundle": "For using a PSR-3 compatible logger implementation with the API PHP describer.",
+                "symfony/security-csrf": "For using csrf protection tokens in forms.",
+                "symfony/serializer": "For describing your models.",
+                "symfony/twig-bundle": "For using the Swagger UI.",
+                "symfony/validator": "For describing the validation constraints in your models.",
+                "willdurand/hateoas-bundle": "For extracting HATEOAS metadata."
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-4.x": "4.x-dev",
+                    "dev-5.x": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nelmio\\ApiDocBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://github.com/nelmio/NelmioApiDocBundle/contributors"
+                }
+            ],
+            "description": "Generates documentation for your REST API from attributes",
+            "keywords": [
+                "api",
+                "doc",
+                "documentation",
+                "rest"
+            ],
+            "support": {
+                "issues": "https://github.com/nelmio/NelmioApiDocBundle/issues",
+                "source": "https://github.com/nelmio/NelmioApiDocBundle/tree/v5.6.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DjordyKoert",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-19T12:23:35+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+            },
+            "time": "2025-08-13T20:13:15+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -7755,6 +7936,92 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "5.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "e25c377ec04db4d2b91186e2debaa1fb135f5cc5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/e25c377ec04db4d2b91186e2debaa1fb135f5cc5",
+                "reference": "e25c377ec04db4d2b91186e2debaa1fb135f5cc5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "nikic/php-parser": "^4.19 || ^5.0",
+                "php": ">=7.4",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": "^5.0 || ^6.0 || ^7.0",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0"
+            },
+            "conflict": {
+                "symfony/process": ">=6, <6.4.14"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11",
+                "doctrine/annotations": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.62.0",
+                "phpstan/phpstan": "^1.6 || ^2.0",
+                "phpunit/phpunit": "^9.0",
+                "rector/rector": "^1.0 || ^2.0",
+                "vimeo/psalm": "^4.30 || ^5.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "^2.0"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "Generate interactive documentation for your RESTful API using PHP attributes (preferred) or PHPDoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/5.4.0"
+            },
+            "time": "2025-09-12T03:49:27+00:00"
         }
     ],
     "packages-dev": [
@@ -8053,64 +8320,6 @@
                 }
             ],
             "time": "2025-08-01T08:46:24+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v5.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-json": "*",
-                "ext-tokenizer": "*",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
-            },
-            "time": "2025-08-13T20:13:15+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -14,4 +14,5 @@ return [
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
     EasyCorp\Bundle\EasyAdminBundle\EasyAdminBundle::class => ['all' => true],
     Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
+    Nelmio\ApiDocBundle\NelmioApiDocBundle::class => ['all' => true],
 ];

--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -1,0 +1,32 @@
+nelmio_api_doc:
+    documentation:
+        info:
+            title: 'Le Trois Quarts - Cart API'
+            description: |
+                🛒 REST API for shopping cart management
+                
+                ## Features
+                - Storage in PHP session (not localStorage)
+                - Prices always from database (secure)
+                - Synchronization between tabs
+                - 24-hour persistence
+                
+                ## Usage
+                All requests require a session cookie.
+                The server will create a new session on the first request.
+                
+            version: '1.0.0'
+            contact:
+                name: 'Le Trois Quarts'
+                url: 'http://127.0.0.1:8000'
+                email: 'contact@letroisquarts.com'
+        servers:
+            - url: 'http://127.0.0.1:8000'
+              description: 'Development server'
+        tags:
+            - name: 'Cart'
+              description: 'Shopping cart operations'
+    areas:
+        path_patterns:
+            - ^/api(?!/doc$) # Accept all /api except /api/doc
+

--- a/config/routes/nelmio_api_doc.yaml
+++ b/config/routes/nelmio_api_doc.yaml
@@ -1,0 +1,13 @@
+# API Documentation routes
+app.swagger_ui:
+    path: /api
+    methods: GET
+    defaults:
+        _controller: nelmio_api_doc.controller.swagger_ui
+
+app.swagger:
+    path: /api/doc.json
+    methods: GET
+    defaults:
+        _controller: nelmio_api_doc.controller.swagger
+

--- a/public/assets/js/cart-api.js
+++ b/public/assets/js/cart-api.js
@@ -1,0 +1,486 @@
+// Cart API functionality for Le Trois Quarts
+// New API-based implementation replacing localStorage
+
+class CartAPI {
+    constructor() {
+        this.baseUrl = '/api/cart';
+    }
+
+    /**
+     * Récupérer le panier depuis le serveur
+     */
+    async getCart() {
+        try {
+            const response = await fetch(this.baseUrl, {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+            
+            if (!response.ok) {
+                throw new Error('Erreur lors de la récupération du panier');
+            }
+            
+            const data = await response.json();
+            return data.success ? data.cart : { items: [], total: 0, itemCount: 0 };
+        } catch (error) {
+            console.error('Erreur getCart:', error);
+            return { items: [], total: 0, itemCount: 0 };
+        }
+    }
+
+    /**
+     * Ajouter un article au panier
+     */
+    async addItem(itemId, quantity = 1) {
+        try {
+            const response = await fetch(`${this.baseUrl}/add`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ itemId, quantity })
+            });
+            
+            const data = await response.json();
+            
+            if (!data.success) {
+                throw new Error(data.message || 'Erreur lors de l\'ajout');
+            }
+            
+            return data.cart;
+        } catch (error) {
+            console.error('Erreur addItem:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Retirer un article du panier
+     */
+    async removeItem(itemId) {
+        try {
+            const response = await fetch(`${this.baseUrl}/remove/${itemId}`, {
+                method: 'DELETE',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+            
+            const data = await response.json();
+            
+            if (!data.success) {
+                throw new Error(data.message || 'Erreur lors de la suppression');
+            }
+            
+            return data.cart;
+        } catch (error) {
+            console.error('Erreur removeItem:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Mettre à jour la quantité d'un article
+     */
+    async updateQuantity(itemId, quantity) {
+        try {
+            const response = await fetch(`${this.baseUrl}/update/${itemId}`, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ quantity })
+            });
+            
+            const data = await response.json();
+            
+            if (!data.success) {
+                throw new Error(data.message || 'Erreur lors de la mise à jour');
+            }
+            
+            return data.cart;
+        } catch (error) {
+            console.error('Erreur updateQuantity:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Vider le panier
+     */
+    async clearCart() {
+        try {
+            const response = await fetch(`${this.baseUrl}/clear`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+            
+            const data = await response.json();
+            
+            if (!data.success) {
+                throw new Error(data.message || 'Erreur lors du vidage');
+            }
+            
+            return data.cart;
+        } catch (error) {
+            console.error('Erreur clearCart:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Obtenir le nombre d'articles
+     */
+    async getCount() {
+        try {
+            const response = await fetch(`${this.baseUrl}/count`, {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+            
+            const data = await response.json();
+            return data.success ? data.count : 0;
+        } catch (error) {
+            console.error('Erreur getCount:', error);
+            return 0;
+        }
+    }
+}
+
+// Instance globale
+window.cartAPI = new CartAPI();
+
+// Global cart toggle function
+window.toggleCart = function() {
+    const cartSidebar = document.getElementById('cartSidebar');
+    if (cartSidebar) {
+        cartSidebar.classList.toggle('open');
+        if (cartSidebar.classList.contains('open')) {
+            document.body.style.overflow = 'hidden';
+            window.cartIsActive = true;
+            // Refresh cart when opening
+            updateCartSidebar();
+        } else {
+            document.body.style.overflow = 'auto';
+            window.cartIsActive = false;
+        }
+    }
+};
+
+// Reset cart active state after a short delay
+window.resetCartActiveState = function() {
+    setTimeout(() => {
+        window.cartIsActive = false;
+    }, 2000);
+};
+
+// Cart navigation functionality
+function initCartNavigation() {
+    const cartNavLink = document.getElementById('cartNavLink');
+    const cartSidebar = document.getElementById('cartSidebar');
+    const closeCart = document.getElementById('closeCart');
+
+    if (cartNavLink) {
+        cartNavLink.addEventListener('click', function(e) {
+            e.preventDefault();
+            toggleCart();
+        });
+    }
+
+    if (closeCart) {
+        closeCart.addEventListener('click', function() {
+            window.cartIsActive = false;
+            toggleCart();
+        });
+    }
+
+    // Close cart when clicking outside
+    document.addEventListener('click', function(e) {
+        if (cartSidebar && cartSidebar.classList.contains('open')) {
+            const isCartControl = e.target.closest('.cart-qty-btn') || 
+                                 e.target.closest('.cart-item-controls') ||
+                                 e.target.closest('.cart-actions') ||
+                                 e.target.closest('.cart-header');
+
+            if (!cartSidebar.contains(e.target) && !cartNavLink.contains(e.target) && !isCartControl) {
+                toggleCart();
+            }
+        }
+    });
+
+    // Close cart with Escape key
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape' && cartSidebar && cartSidebar.classList.contains('open')) {
+            window.cartIsActive = false;
+            toggleCart();
+        }
+    });
+
+    // Update cart count in the navbar
+    updateCartNavigation();
+
+    // Initialize cart sidebar
+    initCartSidebar();
+}
+
+function initCartSidebar() {
+    const clearCartBtn = document.getElementById('clearCart');
+
+    updateCartSidebar();
+
+    // Clear cart button behavior
+    if (clearCartBtn) {
+        clearCartBtn.addEventListener('click', async function() {
+            const confirmed = typeof showConfirmDialog === 'function'
+                ? await new Promise(resolve => {
+                    showConfirmDialog('Confirmation', 'Êtes-vous sûr de vouloir vider votre panier ?', () => resolve(true));
+                })
+                : confirm('Êtes-vous sûr de vouloir vider votre panier ?');
+
+            if (confirmed) {
+                try {
+                    await window.cartAPI.clearCart();
+                    await updateCartNavigation();
+                    await updateCartSidebar();
+                    
+                    // Trigger global renderMenu if available
+                    if (window.renderMenu && typeof window.renderMenu === 'function') {
+                        await window.renderMenu();
+                    }
+                    
+                    window.dispatchEvent(new CustomEvent('cartUpdated'));
+                    
+                    const cartSidebarEl = document.getElementById('cartSidebar');
+                    if (cartSidebarEl && cartSidebarEl.classList.contains('open')) {
+                        cartSidebarEl.classList.remove('open');
+                        document.body.style.overflow = 'auto';
+                        window.cartIsActive = false;
+                    }
+                } catch (error) {
+                    console.error('Erreur lors du vidage du panier:', error);
+                    alert('Erreur lors du vidage du panier');
+                }
+            }
+        });
+    }
+
+    // Order button behavior
+    const orderBtn = document.getElementById('orderBtn');
+    if (orderBtn) {
+        orderBtn.addEventListener('click', async function() {
+            const cart = await window.cartAPI.getCart();
+            if (cart.items.length > 0) {
+                window.location.href = '/order';
+            } else {
+                if (typeof showNotification === 'function') {
+                    showNotification('Votre panier est vide', 'warning');
+                } else {
+                    alert('Votre panier est vide');
+                }
+            }
+        });
+    }
+}
+
+async function updateCartSidebar() {
+    const cartItems = document.getElementById('cartItems');
+    const cartTotal = document.getElementById('cartTotal');
+    const clearCartBtn = document.getElementById('clearCart');
+
+    if (!cartItems || !cartTotal) return;
+
+    try {
+        const cart = await window.cartAPI.getCart();
+
+        // Update clear-cart button state
+        if (clearCartBtn) {
+            if (cart.items.length === 0) {
+                clearCartBtn.disabled = true;
+                clearCartBtn.classList.add('disabled');
+                clearCartBtn.style.opacity = '0.5';
+                clearCartBtn.style.cursor = 'not-allowed';
+            } else {
+                clearCartBtn.disabled = false;
+                clearCartBtn.classList.remove('disabled');
+                clearCartBtn.style.opacity = '1';
+                clearCartBtn.style.cursor = 'pointer';
+            }
+        }
+
+        if (cart.items.length === 0) {
+            cartItems.innerHTML = `
+                <div class="cart-empty">
+                    <i class="bi bi-basket"></i>
+                    <h4>Votre panier est vide</h4>
+                    <p>Ajoutez des plats depuis le menu</p>
+                </div>
+            `;
+            cartTotal.textContent = '0€';
+            return;
+        }
+
+        let itemsHTML = '';
+
+        cart.items.forEach(item => {
+            const itemTotal = item.price * item.quantity;
+
+            itemsHTML += `
+                <div class="cart-item">
+                    <div class="cart-item-header">
+                        <h5 class="cart-item-title">${item.name}</h5>
+                        <span class="cart-item-price">${item.price}€</span>
+                    </div>
+                    <div class="cart-item-controls">
+                        <div class="cart-item-quantity">
+                            <button class="cart-qty-btn" data-action="decrease" data-id="${item.id}">-</button>
+                            <span class="cart-item-total">${item.quantity}</span>
+                            <button class="cart-qty-btn" data-action="increase" data-id="${item.id}">+</button>
+                        </div>
+                        <span class="cart-item-total">${itemTotal.toFixed(2)}€</span>
+                    </div>
+                </div>
+            `;
+        });
+
+        cartItems.innerHTML = itemsHTML;
+        cartTotal.textContent = cart.total.toFixed(2) + '€';
+
+        // Attach event listeners
+        cartItems.querySelectorAll('.cart-qty-btn').forEach(btn => {
+            btn.addEventListener('click', async function(e) {
+                e.preventDefault();
+                window.cartIsActive = true;
+                if (window.resetCartActiveState) window.resetCartActiveState();
+                
+                const id = parseInt(this.getAttribute('data-id'));
+                const action = this.getAttribute('data-action');
+                
+                if (action === 'decrease') {
+                    await window.removeFromCartSidebar(id);
+                } else if (action === 'increase') {
+                    await window.addToCartSidebar(id);
+                }
+            });
+        });
+    } catch (error) {
+        console.error('Erreur updateCartSidebar:', error);
+        cartItems.innerHTML = `
+            <div class="cart-empty">
+                <i class="bi bi-exclamation-triangle"></i>
+                <h4>Erreur de chargement</h4>
+                <p>Impossible de charger le panier</p>
+            </div>
+        `;
+    }
+}
+
+// Global helpers for the sidebar cart
+window.removeFromCartSidebar = async function(itemId) {
+    try {
+        const cart = await window.cartAPI.getCart();
+        const item = cart.items.find(i => i.id === itemId);
+        
+        if (item) {
+            if (item.quantity > 1) {
+                await window.cartAPI.updateQuantity(itemId, item.quantity - 1);
+            } else {
+                await window.cartAPI.removeItem(itemId);
+            }
+            
+            await updateCartSidebar();
+            await updateCartNavigation();
+            
+            if (window.updateQuantityDisplay) {
+                window.updateQuantityDisplay(itemId);
+            }
+            
+            window.dispatchEvent(new CustomEvent('cartUpdated'));
+        }
+    } catch (error) {
+        console.error('Erreur removeFromCartSidebar:', error);
+    }
+};
+
+window.addToCartSidebar = async function(itemId) {
+    try {
+        const cart = await window.cartAPI.getCart();
+        const item = cart.items.find(i => i.id === itemId);
+        
+        if (item) {
+            await window.cartAPI.updateQuantity(itemId, item.quantity + 1);
+            await updateCartSidebar();
+            await updateCartNavigation();
+            
+            if (window.updateQuantityDisplay) {
+                window.updateQuantityDisplay(itemId);
+            }
+            
+            window.dispatchEvent(new CustomEvent('cartUpdated'));
+        }
+    } catch (error) {
+        console.error('Erreur addToCartSidebar:', error);
+    }
+};
+
+// Add a menu item to the cart (menu page)
+window.addMenuItemToCart = async function(itemId) {
+    try {
+        await window.cartAPI.addItem(itemId, 1);
+        await updateCartNavigation();
+        await updateCartSidebar();
+        window.dispatchEvent(new CustomEvent('cartUpdated'));
+    } catch (error) {
+        console.error('Erreur addMenuItemToCart:', error);
+        alert('Erreur lors de l\'ajout au panier');
+    }
+};
+
+// Remove a menu item from the cart (menu page)
+window.removeMenuItemFromCart = async function(itemId) {
+    try {
+        await window.cartAPI.removeItem(itemId);
+        await updateCartNavigation();
+        await updateCartSidebar();
+        window.dispatchEvent(new CustomEvent('cartUpdated'));
+    } catch (error) {
+        console.error('Erreur removeMenuItemFromCart:', error);
+    }
+};
+
+async function updateCartNavigation() {
+    const cartCount = document.getElementById('cartNavCount');
+    if (cartCount) {
+        try {
+            const count = await window.cartAPI.getCount();
+            cartCount.textContent = count;
+            cartCount.classList.remove('hidden');
+        } catch (error) {
+            console.error('Erreur updateCartNavigation:', error);
+        }
+    }
+}
+
+// Initialize cart when DOM is loaded
+document.addEventListener('DOMContentLoaded', function() {
+    updateCartNavigation();
+    initCartNavigation();
+});
+
+// Support Turbo/Hotwire navigation if present
+window.addEventListener('turbo:load', function() {
+    updateCartNavigation();
+    initCartNavigation();
+});
+
+// Export functions globally for compatibility
+window.updateCartNavigation = updateCartNavigation;
+window.updateCartSidebar = updateCartSidebar;
+window.initCartNavigation = initCartNavigation;
+window.initCartSidebar = initCartSidebar;
+

--- a/src/Controller/CartController.php
+++ b/src/Controller/CartController.php
@@ -1,0 +1,398 @@
+<?php
+
+namespace App\Controller;
+
+use App\Service\CartService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use OpenApi\Attributes as OA;
+
+#[Route('/api/cart')]
+#[OA\Tag(name: 'Cart')]
+class CartController extends AbstractController
+{
+    public function __construct(
+        private CartService $cartService
+    ) {}
+
+    /**
+     * Get cart contents
+     */
+    #[Route('', name: 'api_cart_get', methods: ['GET'])]
+    #[OA\Get(
+        path: '/api/cart',
+        summary: 'Get cart',
+        description: 'Returns the contents of the current session cart',
+        tags: ['Cart']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Successful response',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(
+                    property: 'cart',
+                    properties: [
+                        new OA\Property(property: 'items', type: 'array', items: new OA\Items(
+                            properties: [
+                                new OA\Property(property: 'id', type: 'integer', example: 1),
+                                new OA\Property(property: 'name', type: 'string', example: 'Risotto aux champignons'),
+                                new OA\Property(property: 'price', type: 'number', format: 'float', example: 14.5),
+                                new OA\Property(property: 'quantity', type: 'integer', example: 2),
+                                new OA\Property(property: 'image', type: 'string', example: '/uploads/menu/plat_1.png'),
+                                new OA\Property(property: 'category', type: 'string', example: 'plats')
+                            ],
+                            type: 'object'
+                        )),
+                        new OA\Property(property: 'total', type: 'number', format: 'float', example: 29.0),
+                        new OA\Property(property: 'itemCount', type: 'integer', example: 2)
+                    ],
+                    type: 'object'
+                )
+            ]
+        )
+    )]
+    public function getCart(): JsonResponse
+    {
+        try {
+            $cart = $this->cartService->getCart();
+            
+            return $this->json([
+                'success' => true,
+                'cart' => $cart
+            ]);
+        } catch (\Exception $e) {
+            return $this->json([
+                'success' => false,
+                'message' => 'Erreur lors de la récupération du panier: ' . $e->getMessage()
+            ], 500);
+        }
+    }
+
+    /**
+     * Add item to cart
+     */
+    #[Route('/add', name: 'api_cart_add', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/cart/add',
+        summary: 'Add item to cart',
+        description: 'Adds an item to the cart or increases quantity if item already exists',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'itemId', type: 'integer', example: 1, description: 'Menu item ID from database'),
+                    new OA\Property(property: 'quantity', type: 'integer', example: 1, description: 'Quantity (default: 1)')
+                ],
+                type: 'object'
+            )
+        ),
+        tags: ['Cart']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Item added successfully',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'message', type: 'string', example: 'Article ajouté au panier'),
+                new OA\Property(
+                    property: 'cart',
+                    properties: [
+                        new OA\Property(property: 'items', type: 'array', items: new OA\Items()),
+                        new OA\Property(property: 'total', type: 'number', example: 29.0),
+                        new OA\Property(property: 'itemCount', type: 'integer', example: 2)
+                    ],
+                    type: 'object'
+                )
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 400,
+        description: 'Invalid data',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: false),
+                new OA\Property(property: 'message', type: 'string', example: 'itemId est requis')
+            ]
+        )
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Item not found',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: false),
+                new OA\Property(property: 'message', type: 'string', example: 'Menu item not found: 999')
+            ]
+        )
+    )]
+    public function addToCart(Request $request): JsonResponse
+    {
+        try {
+            $data = json_decode($request->getContent(), true);
+            
+            if (!isset($data['itemId'])) {
+                return $this->json([
+                    'success' => false,
+                    'message' => 'itemId est requis'
+                ], 400);
+            }
+
+            $itemId = (int) $data['itemId'];
+            $quantity = isset($data['quantity']) ? (int) $data['quantity'] : 1;
+
+            if ($quantity < 1) {
+                return $this->json([
+                    'success' => false,
+                    'message' => 'La quantité doit être au moins 1'
+                ], 400);
+            }
+
+            $cart = $this->cartService->add($itemId, $quantity);
+
+            return $this->json([
+                'success' => true,
+                'message' => 'Article ajouté au panier',
+                'cart' => $cart
+            ]);
+
+        } catch (\InvalidArgumentException $e) {
+            return $this->json([
+                'success' => false,
+                'message' => $e->getMessage()
+            ], 404);
+        } catch (\Exception $e) {
+            return $this->json([
+                'success' => false,
+                'message' => 'Erreur lors de l\'ajout au panier: ' . $e->getMessage()
+            ], 500);
+        }
+    }
+
+    /**
+     * Remove item from cart
+     */
+    #[Route('/remove/{id}', name: 'api_cart_remove', methods: ['DELETE'])]
+    #[OA\Delete(
+        path: '/api/cart/remove/{id}',
+        summary: 'Remove item',
+        description: 'Completely removes an item from the cart',
+        tags: ['Cart']
+    )]
+    #[OA\Parameter(
+        name: 'id',
+        in: 'path',
+        required: true,
+        description: 'Item ID',
+        schema: new OA\Schema(type: 'integer', example: 1)
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Item removed successfully',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'message', type: 'string', example: 'Article retiré du panier'),
+                new OA\Property(
+                    property: 'cart',
+                    properties: [
+                        new OA\Property(property: 'items', type: 'array', items: new OA\Items()),
+                        new OA\Property(property: 'total', type: 'number', example: 0),
+                        new OA\Property(property: 'itemCount', type: 'integer', example: 0)
+                    ],
+                    type: 'object'
+                )
+            ]
+        )
+    )]
+    public function removeFromCart(int $id): JsonResponse
+    {
+        try {
+            $cart = $this->cartService->remove($id);
+
+            return $this->json([
+                'success' => true,
+                'message' => 'Article retiré du panier',
+                'cart' => $cart
+            ]);
+        } catch (\InvalidArgumentException $e) {
+            return $this->json([
+                'success' => false,
+                'message' => $e->getMessage()
+            ], 404);
+        } catch (\Exception $e) {
+            return $this->json([
+                'success' => false,
+                'message' => 'Erreur lors de la suppression: ' . $e->getMessage()
+            ], 500);
+        }
+    }
+
+    /**
+     * Update item quantity
+     */
+    #[Route('/update/{id}', name: 'api_cart_update', methods: ['PUT'])]
+    #[OA\Put(
+        path: '/api/cart/update/{id}',
+        summary: 'Update quantity',
+        description: 'Updates item quantity. If quantity = 0, item is removed',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'quantity', type: 'integer', example: 3, description: 'New quantity')
+                ],
+                type: 'object'
+            )
+        ),
+        tags: ['Cart']
+    )]
+    #[OA\Parameter(
+        name: 'id',
+        in: 'path',
+        required: true,
+        description: 'Item ID',
+        schema: new OA\Schema(type: 'integer', example: 1)
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Quantity updated successfully',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'message', type: 'string', example: 'Quantité mise à jour'),
+                new OA\Property(
+                    property: 'cart',
+                    properties: [
+                        new OA\Property(property: 'items', type: 'array', items: new OA\Items()),
+                        new OA\Property(property: 'total', type: 'number', example: 43.5),
+                        new OA\Property(property: 'itemCount', type: 'integer', example: 3)
+                    ],
+                    type: 'object'
+                )
+            ]
+        )
+    )]
+    public function updateQuantity(int $id, Request $request): JsonResponse
+    {
+        try {
+            $data = json_decode($request->getContent(), true);
+            
+            if (!isset($data['quantity'])) {
+                return $this->json([
+                    'success' => false,
+                    'message' => 'quantity est requis'
+                ], 400);
+            }
+
+            $quantity = (int) $data['quantity'];
+            $cart = $this->cartService->updateQuantity($id, $quantity);
+
+            return $this->json([
+                'success' => true,
+                'message' => 'Quantité mise à jour',
+                'cart' => $cart
+            ]);
+        } catch (\InvalidArgumentException $e) {
+            return $this->json([
+                'success' => false,
+                'message' => $e->getMessage()
+            ], 404);
+        } catch (\Exception $e) {
+            return $this->json([
+                'success' => false,
+                'message' => 'Erreur lors de la mise à jour: ' . $e->getMessage()
+            ], 500);
+        }
+    }
+
+    /**
+     * Clear cart
+     */
+    #[Route('/clear', name: 'api_cart_clear', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/cart/clear',
+        summary: 'Clear cart',
+        description: 'Removes all items from the cart',
+        tags: ['Cart']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Cart cleared successfully',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'message', type: 'string', example: 'Panier vidé'),
+                new OA\Property(
+                    property: 'cart',
+                    properties: [
+                        new OA\Property(property: 'items', type: 'array', items: new OA\Items()),
+                        new OA\Property(property: 'total', type: 'number', example: 0),
+                        new OA\Property(property: 'itemCount', type: 'integer', example: 0)
+                    ],
+                    type: 'object'
+                )
+            ]
+        )
+    )]
+    public function clearCart(): JsonResponse
+    {
+        try {
+            $cart = $this->cartService->clear();
+
+            return $this->json([
+                'success' => true,
+                'message' => 'Panier vidé',
+                'cart' => $cart
+            ]);
+        } catch (\Exception $e) {
+            return $this->json([
+                'success' => false,
+                'message' => 'Erreur lors du vidage du panier: ' . $e->getMessage()
+            ], 500);
+        }
+    }
+
+    /**
+     * Get item count
+     */
+    #[Route('/count', name: 'api_cart_count', methods: ['GET'])]
+    #[OA\Get(
+        path: '/api/cart/count',
+        summary: 'Get item count',
+        description: 'Returns the total number of items in the cart (useful for badge updates)',
+        tags: ['Cart']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Successful response',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'count', type: 'integer', example: 3, description: 'Total number of items')
+            ]
+        )
+    )]
+    public function getCartCount(): JsonResponse
+    {
+        try {
+            $count = $this->cartService->getItemCount();
+
+            return $this->json([
+                'success' => true,
+                'count' => $count
+            ]);
+        } catch (\Exception $e) {
+            return $this->json([
+                'success' => false,
+                'message' => 'Erreur: ' . $e->getMessage()
+            ], 500);
+        }
+    }
+}
+

--- a/src/Service/CartService.php
+++ b/src/Service/CartService.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace App\Service;
+
+use App\Repository\MenuItemRepository;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Service pour gérer le panier de commande.
+ * Stocke les données dans la session utilisateur.
+ */
+class CartService
+{
+    private const CART_SESSION_KEY = 'cart';
+
+    public function __construct(
+        private RequestStack $requestStack,
+        private MenuItemRepository $menuItemRepository
+    ) {}
+
+    /**
+     * Ajouter un article au panier
+     */
+    public function add(int $menuItemId, int $quantity = 1): array
+    {
+        $session = $this->requestStack->getSession();
+        $cart = $session->get(self::CART_SESSION_KEY, []);
+
+        // Si l'article existe déjà, augmenter la quantité
+        if (isset($cart[$menuItemId])) {
+            $cart[$menuItemId]['quantity'] += $quantity;
+        } else {
+            // Récupérer les détails du produit
+            $menuItem = $this->menuItemRepository->find($menuItemId);
+            
+            if (!$menuItem) {
+                throw new \InvalidArgumentException("Menu item not found: $menuItemId");
+            }
+
+            $cart[$menuItemId] = [
+                'id' => $menuItem->getId(),
+                'name' => $menuItem->getName(),
+                'price' => (float) $menuItem->getPrice(),
+                'image' => $this->resolveImagePath($menuItem->getImage()),
+                'category' => $menuItem->getCategory(),
+                'quantity' => $quantity,
+            ];
+        }
+
+        $session->set(self::CART_SESSION_KEY, $cart);
+        
+        return $this->getCartDetails($cart);
+    }
+
+    /**
+     * Retirer un article du panier
+     */
+    public function remove(int $menuItemId): array
+    {
+        $session = $this->requestStack->getSession();
+        $cart = $session->get(self::CART_SESSION_KEY, []);
+
+        if (!isset($cart[$menuItemId])) {
+            throw new \InvalidArgumentException("Cart item not found: $menuItemId");
+        }
+
+        unset($cart[$menuItemId]);
+        $session->set(self::CART_SESSION_KEY, $cart);
+
+        return $this->getCartDetails($cart);
+    }
+
+    /**
+     * Mettre à jour la quantité d'un article
+     */
+    public function updateQuantity(int $menuItemId, int $quantity): array
+    {
+        $session = $this->requestStack->getSession();
+        $cart = $session->get(self::CART_SESSION_KEY, []);
+
+        if (!isset($cart[$menuItemId])) {
+            throw new \InvalidArgumentException("Cart item not found: $menuItemId");
+        }
+
+        if ($quantity <= 0) {
+            unset($cart[$menuItemId]);
+        } else {
+            $cart[$menuItemId]['quantity'] = $quantity;
+        }
+        $session->set(self::CART_SESSION_KEY, $cart);
+
+        return $this->getCartDetails($cart);
+    }
+
+    /**
+     * Obtenir le contenu du panier avec les détails
+     */
+    public function getCart(): array
+    {
+        $session = $this->requestStack->getSession();
+        $cart = $session->get(self::CART_SESSION_KEY, []);
+        
+        return $this->getCartDetails($cart);
+    }
+
+    /**
+     * Vider le panier
+     */
+    public function clear(): array
+    {
+        $session = $this->requestStack->getSession();
+        $session->remove(self::CART_SESSION_KEY);
+        
+        return $this->getCartDetails([]);
+    }
+
+    /**
+     * Obtenir le nombre total d'articles dans le panier
+     */
+    public function getItemCount(): int
+    {
+        $session = $this->requestStack->getSession();
+        $cart = $session->get(self::CART_SESSION_KEY, []);
+        
+        $count = 0;
+        foreach ($cart as $item) {
+            $count += $item['quantity'];
+        }
+        
+        return $count;
+    }
+
+    /**
+     * Calculer le total du panier
+     */
+    public function getTotal(): float
+    {
+        $session = $this->requestStack->getSession();
+        $cart = $session->get(self::CART_SESSION_KEY, []);
+        
+        $total = 0;
+        foreach ($cart as $item) {
+            $total += $item['price'] * $item['quantity'];
+        }
+        
+        return round($total, 2);
+    }
+
+    /**
+     * Formater les détails du panier pour l'API
+     */
+    private function getCartDetails(array $cart): array
+    {
+        $items = array_values($cart);
+        $total = 0;
+        $itemCount = 0;
+
+        foreach ($items as $item) {
+            $total += $item['price'] * $item['quantity'];
+            $itemCount += $item['quantity'];
+        }
+
+        return [
+            'items' => $items,
+            'total' => round($total, 2),
+            'itemCount' => $itemCount,
+        ];
+    }
+
+    /**
+     * Résoudre le chemin de l'image
+     */
+    private function resolveImagePath(?string $image): string
+    {
+        if (!$image) {
+            return '/assets/img/default-dish.png';
+        }
+
+        if (str_starts_with($image, 'http')) {
+            return $image;
+        }
+
+        if (str_starts_with($image, '/uploads/') || str_starts_with($image, '/assets/')) {
+            return $image;
+        }
+
+        if (str_starts_with($image, 'assets/')) {
+            return '/' . $image;
+        }
+
+        return '/uploads/menu/' . ltrim($image, '/');
+    }
+}
+

--- a/symfony.lock
+++ b/symfony.lock
@@ -59,6 +59,15 @@
             "./config/routes/easyadmin.yaml"
         ]
     },
+    "nelmio/api-doc-bundle": {
+        "version": "5.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "3.0",
+            "ref": "c8e0c38e1a280ab9e37587a8fa32b251d5bc1c94"
+        }
+    },
     "phpunit/phpunit": {
         "version": "11.5",
         "recipe": {

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -17,8 +17,8 @@
     {# JavaScripts block (can be overridden on child pages) #}
     {% block javascripts %}
         {% block importmap %}{{ importmap('app') }}{% endblock %}
-        {# Cart functionality #}
-        <script src="{{ asset('assets/js/cart.js') }}?v=3"></script>
+        {# Cart functionality - API version #}
+        <script src="{{ asset('assets/js/cart-api.js') }}?v=4"></script>
         <script src="{{ asset('assets/js/global.js') }}"></script>
     {% endblock %}
 </head>

--- a/templates/pages/dish_detail.html.twig
+++ b/templates/pages/dish_detail.html.twig
@@ -183,7 +183,7 @@
 
 {% block javascripts %}
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="{{ asset('assets/js/cart.js') }}?v=3"></script>
+    <script src="{{ asset('assets/js/cart-api.js') }}?v=4"></script>
     <script src="{{ asset('assets/js/global.js') }}"></script>
     <script src="{{ asset('assets/js/main.js') }}"></script>
     <script>


### PR DESCRIPTION
Add CartService with session storage, totals and itemCount

Implement CartController endpoints:
- POST /api/cart/add
- DELETE /api/cart/remove/{id}
- PUT /api/cart/update/{id}
- GET /api/cart
- GET /api/cart/count
- POST /api/cart/clear

Integrate NelmioApiDocBundle; expose Swagger UI at /api

Migrate frontend to window.cartAPI (fetch) from localStorage

Menu & dish pages: async updates, sidebar sync, custom events

Fix ID type mismatches and bfcache/back navigation sync

Stop full menu re-renders; update only affected cards

perf(menu): avoid extra getCart calls after mutations by using API response

docs(api): translate OpenAPI to English and refine inline schemas