### PR TITLE
feat(reviews-api): add REST endpoints and front integration

### DIFF
--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -1,9 +1,9 @@
 nelmio_api_doc:
     documentation:
         info:
-            title: 'Le Trois Quarts - Cart API'
+            title: 'Le Trois Quarts - API'
             description: |
-                🛒 REST API for shopping cart management
+                🛒 REST API for shopping cart and reviews management
                 
                 ## Features
                 - Storage in PHP session (not localStorage)
@@ -26,6 +26,8 @@ nelmio_api_doc:
         tags:
             - name: 'Cart'
               description: 'Shopping cart operations'
+            - name: 'Reviews'
+              description: 'Customer reviews operations'
     areas:
         path_patterns:
             - ^/api(?!/doc$) # Accept all /api except /api/doc

--- a/public/assets/js/dish-detail.js
+++ b/public/assets/js/dish-detail.js
@@ -305,10 +305,8 @@ function addCartUpdateListener(dish) {
         updateQuantityDisplay(dish.id);
     });
     
-    // Set up interval to check for cart changes (fallback)
-    setInterval(() => {
-        updateQuantityDisplay(dish.id);
-    }, 1000);
+    // Polling removed to avoid excessive API calls on dish page.
+    // Updates now rely on 'storage' and 'cartUpdated' events only.
 }
 
 // ---------------- DISH REVIEWS ----------------

--- a/src/Controller/DishReviewApiController.php
+++ b/src/Controller/DishReviewApiController.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\MenuItem;
+use App\Entity\Review;
+use App\Repository\ReviewRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/dishes')]
+#[OA\Tag(name: 'Reviews')]
+class DishReviewApiController extends AbstractController
+{
+    #[Route('/{id}/reviews', name: 'api_dish_reviews_list', methods: ['GET'])]
+    #[OA\Get(path: '/api/dishes/{id}/reviews', summary: 'List approved reviews for a dish', tags: ['Reviews'])]
+    #[OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))]
+    #[OA\Response(response: 200, description: 'OK', content: new OA\JsonContent(type: 'object', properties: [
+        new OA\Property(property: 'success', type: 'boolean', example: true),
+        new OA\Property(property: 'reviews', type: 'array', items: new OA\Items(type: 'object'))
+    ]))]
+    public function list(MenuItem $id, ReviewRepository $repo): JsonResponse
+    {
+        $reviews = $repo->createQueryBuilder('r')
+            ->andWhere('r.menuItem = :id')
+            ->andWhere('r.isApproved = 1')
+            ->setParameter('id', $id->getId())
+            ->orderBy('r.createdAt', 'DESC')
+            ->setMaxResults(100)
+            ->getQuery()
+            ->getResult();
+
+        $data = array_map(static function (Review $r) {
+            return [
+                'id' => $r->getId(),
+                'name' => $r->getName(),
+                'rating' => $r->getRating(),
+                'comment' => $r->getComment(),
+                'createdAt' => $r->getCreatedAt()->format('Y-m-d H:i'),
+            ];
+        }, $reviews);
+
+        return $this->json(['success' => true, 'reviews' => $data]);
+    }
+
+    #[Route('/{id}/review', name: 'api_dish_reviews_add', methods: ['POST'])]
+    #[OA\Post(path: '/api/dishes/{id}/review', summary: 'Submit a review for a dish (pending moderation)', tags: ['Reviews'])]
+    #[OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer'))]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object', properties: [
+        new OA\Property(property: 'name', type: 'string'),
+        new OA\Property(property: 'email', type: 'string', nullable: true),
+        new OA\Property(property: 'rating', type: 'integer', minimum: 1, maximum: 5),
+        new OA\Property(property: 'comment', type: 'string')
+    ]))]
+    #[OA\Response(response: 200, description: 'Accepted', content: new OA\JsonContent(type: 'object', properties: [
+        new OA\Property(property: 'success', type: 'boolean', example: true),
+        new OA\Property(property: 'message', type: 'string')
+    ]))]
+    public function add(MenuItem $id, Request $request, EntityManagerInterface $em): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            return $this->json(['success' => false, 'message' => 'Invalid JSON'], 400);
+        }
+
+        $name = trim((string) ($data['name'] ?? ''));
+        $email = trim((string) ($data['email'] ?? ''));
+        $rating = (int) ($data['rating'] ?? 0);
+        $comment = trim((string) ($data['comment'] ?? ''));
+
+        $errors = [];
+        if ($name === '' || mb_strlen($name) < 2) { $errors[] = 'Name must be at least 2 characters'; }
+        if ($email !== '' && !filter_var($email, FILTER_VALIDATE_EMAIL)) { $errors[] = 'Email is not valid'; }
+        if ($rating < 1 || $rating > 5) { $errors[] = 'Rating must be between 1 and 5'; }
+        if ($comment === '' || mb_strlen($comment) < 10) { $errors[] = 'Comment must be at least 10 characters'; }
+
+        if ($errors) {
+            return $this->json(['success' => false, 'message' => 'Validation error', 'errors' => $errors], 400);
+        }
+
+        $review = (new Review())
+            ->setName($name)
+            ->setEmail($email !== '' ? $email : null)
+            ->setRating($rating)
+            ->setComment($comment)
+            ->setIsApproved(false)
+            ->setMenuItem($id);
+
+        $em->persist($review);
+        $em->flush();
+
+        return $this->json(['success' => true, 'message' => 'Review submitted. Pending approval.']);
+    }
+}
+
+

--- a/src/Controller/DishReviewController.php
+++ b/src/Controller/DishReviewController.php
@@ -52,11 +52,19 @@ class DishReviewController extends AbstractController
     #[Route('', name: 'dish_reviews_add', methods: ['POST'])]
     public function add(MenuItem $item, Request $request, EntityManagerInterface $em): JsonResponse
     {
-        // Basic request validation; server-side form/validator can be added later if needed
-        $name = trim((string) $request->request->get('name', ''));
-        $email = trim((string) $request->request->get('email', ''));
-        $rating = (int) $request->request->get('rating', 0);
-        $comment = trim((string) $request->request->get('comment', ''));
+        // Accept both JSON and form-encoded payloads
+        $data = json_decode($request->getContent(), true);
+        if (is_array($data)) {
+            $name = trim((string) ($data['name'] ?? ''));
+            $email = trim((string) ($data['email'] ?? ''));
+            $rating = (int) ($data['rating'] ?? 0);
+            $comment = trim((string) ($data['comment'] ?? ''));
+        } else {
+            $name = trim((string) $request->request->get('name', ''));
+            $email = trim((string) $request->request->get('email', ''));
+            $rating = (int) $request->request->get('rating', 0);
+            $comment = trim((string) $request->request->get('comment', ''));
+        }
 
         if ($name === '' || $rating < 1 || $rating > 5 || mb_strlen($comment) < 10) {
             return $this->json(['success' => false, 'message' => 'Invalid data'], 400);

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -34,71 +34,7 @@ class HomeController extends AbstractController
         ]);
     }
 
-    #[Route('/submit-review', name: 'app_submit_review', methods: ['POST'])]
-    public function submitReview(Request $request, EntityManagerInterface $entityManager): JsonResponse
-    {
-        // Check if it's an AJAX request
-        if (!$request->isXmlHttpRequest()) {
-            return new JsonResponse(['success' => false, 'message' => 'Requête invalide'], 400);
-        }
-        
-        try {
-            // Get form data directly from request
-            $name = $request->request->get('name', '');
-            $email = $request->request->get('email', '');
-            $rating = $request->request->get('rating', 0);
-            $comment = $request->request->get('comment', '');
-            
-            // Basic validation
-            $errors = [];
-            
-            if (empty($name) || strlen($name) < 2) {
-                $errors[] = 'Le nom doit contenir au moins 2 caractères';
-            }
-            
-            if (!empty($email) && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
-                $errors[] = 'L\'email n\'est pas valide';
-            }
-            
-            if (empty($rating) || $rating < 1 || $rating > 5) {
-                $errors[] = 'Veuillez sélectionner une note entre 1 et 5';
-            }
-            
-            if (empty($comment) || strlen($comment) < 10) {
-                $errors[] = 'Le commentaire doit contenir au moins 10 caractères';
-            }
-            
-            if (!empty($errors)) {
-                return new JsonResponse([
-                    'success' => false,
-                    'message' => 'Erreur de validation. Veuillez vérifier vos données.',
-                    'errors' => $errors
-                ], 400);
-            }
-            
-            // Create and save review
-            $review = new Review();
-            $review->setName($name);
-            $review->setEmail($email ?: null);
-            $review->setRating((int)$rating);
-            $review->setComment($comment);
-            $review->setIsApproved(false); // Requires moderation
-            
-            $entityManager->persist($review);
-            $entityManager->flush();
-            
-            return new JsonResponse([
-                'success' => true,
-                'message' => 'Merci pour votre avis ! Il sera publié après modération.'
-            ]);
-            
-        } catch (\Exception $e) {
-            return new JsonResponse([
-                'success' => false,
-                'message' => 'Une erreur est survenue lors de l\'enregistrement de votre avis.'
-            ], 500);
-        }
-    }
+    
 
     #[Route('/menu', name: 'app_menu')]
     public function menu(): Response

--- a/src/Controller/ReviewController.php
+++ b/src/Controller/ReviewController.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Review;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api')]
+#[OA\Tag(name: 'Reviews')]
+class ReviewController extends AbstractController
+{
+    #[Route('/reviews', name: 'api_reviews_list', methods: ['GET'])]
+    #[OA\Get(
+        path: '/api/reviews',
+        summary: 'List approved reviews',
+        description: 'Returns latest approved reviews for the restaurant. Use dish endpoints for dish-specific reviews.',
+        tags: ['Reviews']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Successful response',
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(
+                    property: 'reviews',
+                    type: 'array',
+                    items: new OA\Items(type: 'object', properties: [
+                        new OA\Property(property: 'id', type: 'integer', example: 12),
+                        new OA\Property(property: 'name', type: 'string', example: 'Alice'),
+                        new OA\Property(property: 'rating', type: 'integer', example: 5),
+                        new OA\Property(property: 'comment', type: 'string', example: 'Great food!'),
+                        new OA\Property(property: 'createdAt', type: 'string', example: '2025-09-20 18:30')
+                    ])
+                )
+            ]
+        )
+    )]
+    public function list(EntityManagerInterface $em): JsonResponse
+    {
+        $qb = $em->getRepository(Review::class)->createQueryBuilder('r')
+            ->andWhere('r.menuItem IS NULL')
+            ->andWhere('r.isApproved = 1')
+            ->orderBy('r.createdAt', 'DESC')
+            ->setMaxResults(100);
+
+        $reviews = $qb->getQuery()->getResult();
+
+        $data = array_map(static function (Review $r) {
+            return [
+                'id' => $r->getId(),
+                'name' => $r->getName(),
+                'rating' => $r->getRating(),
+                'comment' => $r->getComment(),
+                'createdAt' => $r->getCreatedAt()?->format('Y-m-d H:i'),
+            ];
+        }, $reviews);
+
+        return $this->json(['success' => true, 'reviews' => $data]);
+    }
+
+    #[Route('/review', name: 'api_review_create', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/review',
+        summary: 'Submit a new review (pending moderation)',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                type: 'object',
+                properties: [
+                    new OA\Property(property: 'name', type: 'string', example: 'Alice'),
+                    new OA\Property(property: 'email', type: 'string', example: 'alice@example.com', nullable: true),
+                    new OA\Property(property: 'rating', type: 'integer', example: 5, minimum: 1, maximum: 5),
+                    new OA\Property(property: 'comment', type: 'string', example: 'Great food and service!')
+                ]
+            )
+        ),
+        tags: ['Reviews']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Review accepted for moderation',
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'message', type: 'string', example: 'Review submitted. Pending approval.')
+            ]
+        )
+    )]
+    public function create(Request $request, EntityManagerInterface $em): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            return $this->json(['success' => false, 'message' => 'Invalid JSON'], 400);
+        }
+
+        $name = trim((string)($data['name'] ?? ''));
+        $email = trim((string)($data['email'] ?? ''));
+        $rating = (int)($data['rating'] ?? 0);
+        $comment = trim((string)($data['comment'] ?? ''));
+
+        $errors = [];
+        if ($name === '' || mb_strlen($name) < 2) { $errors[] = 'Name must be at least 2 characters'; }
+        if ($email !== '' && !filter_var($email, FILTER_VALIDATE_EMAIL)) { $errors[] = 'Email is not valid'; }
+        if ($rating < 1 || $rating > 5) { $errors[] = 'Rating must be between 1 and 5'; }
+        if ($comment === '' || mb_strlen($comment) < 10) { $errors[] = 'Comment must be at least 10 characters'; }
+
+        if ($errors) {
+            return $this->json(['success' => false, 'message' => 'Validation error', 'errors' => $errors], 400);
+        }
+
+        $review = (new Review())
+            ->setName($name)
+            ->setEmail($email !== '' ? $email : null)
+            ->setRating($rating)
+            ->setComment($comment)
+            ->setIsApproved(false);
+
+        $em->persist($review);
+        $em->flush();
+
+        return $this->json(['success' => true, 'message' => 'Review submitted. Pending approval.']);
+    }
+}
+
+

--- a/templates/home/homepage.html.twig
+++ b/templates/home/homepage.html.twig
@@ -327,6 +327,9 @@
     <!-- Main JS -->
     <script src="{{ asset('assets/js/main.js') }}"></script>
     <!-- Custom JS -->
+    <script>
+        window.REVIEWS_ENDPOINT = '/api/review';
+    </script>
     <script src="{{ asset('assets/js/reviews.js') }}"></script>
     
     

--- a/templates/pages/dish_detail.html.twig
+++ b/templates/pages/dish_detail.html.twig
@@ -187,8 +187,8 @@
     <script src="{{ asset('assets/js/global.js') }}"></script>
     <script src="{{ asset('assets/js/main.js') }}"></script>
     <script>
-        // Endpoint override so reviews.js posts to dish-specific URL
-        window.REVIEWS_ENDPOINT = '/dish/{{ item.id }}/reviews';
+        // Endpoint override so reviews.js posts to dish-specific API URL
+        window.REVIEWS_ENDPOINT = '/api/dishes/{{ item.id }}/review';
     </script>
     <script src="{{ asset('assets/js/reviews.js') }}"></script>
     <script src="{{ asset('assets/js/dish-detail.js') }}"></script>

--- a/templates/pages/reviews.html.twig
+++ b/templates/pages/reviews.html.twig
@@ -184,6 +184,10 @@
 
 {% block javascripts %}
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        window.REVIEWS_ENDPOINT = '/api/review';
+        window.REVIEWS_LIST_ENDPOINT = '/api/reviews';
+    </script>
     <script src="{{ asset('assets/js/main.js') }}"></script>
     <script src="{{ asset('assets/js/reviews.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
Add ReviewController with POST /api/review and GET /api/reviews

Add dish-specific API: GET /api/dishes/{id}/reviews, POST /api/dishes/{id}/review

Integrate POST on homepage and reviews page; dish page posts to dish API

Wire reviews list on reviews page to GET /api/reviews

Document endpoints in OpenAPI (Nelmio) with 'Reviews' tag

Refactor: remove legacy /submit-review handler