### PR TITLE
feat(404): build error page to match Restaurant design and keep sit…

### DIFF
--- a/public/assets/css/404.css
+++ b/public/assets/css/404.css
@@ -1,11 +1,16 @@
 /* 404 page styles */
-
+body {
+    background: linear-gradient(135deg, rgba(212, 165, 116, 0.1), rgba(139, 69, 19, 0.1)) !important;
+}
 .error-section {
-    min-height: 100vh;
+    background: transparent;
+}
+.error-section {
+    min-height: 100vh; /* revert to full viewport height */
     display: flex;
-    align-items: center;
-    background: linear-gradient(135deg, rgba(212, 165, 116, 0.1), rgba(139, 69, 19, 0.1));
-    padding: 120px 0 80px;
+    align-items: center; /* vertical centering of single-line content */
+    justify-content: center; /* center content block vertically within flex */
+    padding: 0; /* spacing handled by row pt-5 */
 }
 
 .error-content {

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -236,6 +236,6 @@ class HomeController extends AbstractController
     #[Route('/404', name: 'app_404')]
     public function notFound(): Response
     {
-        return $this->render('pages/404.html.twig');
+        throw $this->createNotFoundException('Page not found');
     }
 }

--- a/src/DataFixtures/DrinkFixtures.php
+++ b/src/DataFixtures/DrinkFixtures.php
@@ -65,3 +65,4 @@ class DrinkFixtures extends Fixture implements FixtureGroupInterface
 
 
 
+

--- a/src/DataFixtures/TagFixtures.php
+++ b/src/DataFixtures/TagFixtures.php
@@ -47,3 +47,4 @@ class TagFixtures extends Fixture implements FixtureGroupInterface
 
 
 
+

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -10,7 +10,15 @@
 
     {# Stylesheets block (can be overridden on child pages) #}
     {% block stylesheets %}
+        {# Global third-party styles used site-wide #}
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
+        <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+
+        {# Site styles #}
         <link rel="stylesheet" href="{{ asset('assets/css/global.css') }}">
+        <link rel="stylesheet" href="{{ asset('assets/css/style.css') }}?v={{ 'now'|date('YmdHis') }}">
+        {# 404.css is loaded only on the 404 page to avoid global overrides #}
     {% endblock %}
     
 
@@ -20,6 +28,7 @@
         {# Cart functionality - API version #}
         <script src="{{ asset('assets/js/cart-api.js') }}?v=4"></script>
         <script src="{{ asset('assets/js/global.js') }}"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     {% endblock %}
 </head>
 <body>

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -1,0 +1,61 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Page non trouvée ({{ status_code|default(404) }}){% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('assets/css/404.css') }}?v=4">
+{% endblock %}
+
+{% block body %}
+    <section class="error-section">
+        <div class="container">
+            <div class="error-content">
+                <div class="error-illustration">
+                    <div class="error-number">{{ status_code|default(404) }}</div>
+                    <div class="error-icon">☕</div>
+                </div>
+
+                <h1 class="error-title">Oups ! Page non trouvée</h1>
+                <p class="error-message">Il semblerait que cette page ait disparu comme un bon plat qui se termine trop vite !<br>Mais ne vous inquiétez pas, nous avons plein d'autres délices à vous proposer.</p>
+
+                <div class="error-actions d-flex justify-content-center gap-3 flex-wrap">
+                    <a href="{{ path('app_home') }}" class="btn btn-gold"><span class="me-2">🏠</span>RETOUR À L'ACCUEIL</a>
+                    <a href="{{ path('app_menu') }}" class="btn btn-outline-gold"><span class="me-2">📜</span>VOIR LE MENU</a>
+                </div>
+
+                <div class="error-suggestions">
+                    <h4 class="mb-4">Peut-être cherchez-vous :</h4>
+                    <div class="row g-4">
+                        <div class="col-md-4">
+                            <div class="suggestion-card">
+                                <i>🗓️</i>
+                                <h5>Réserver une table</h5>
+                                <p>Planifiez votre visite et profitez d'une expérience gourmande.</p>
+                                <a href="{{ path('app_reservation') }}" class="btn btn-gold">Réserver</a>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="suggestion-card">
+                                <i>🛍️</i>
+                                <h5>Voir le menu</h5>
+                                <p>Parcourez notre carte et trouvez votre prochain coup de cœur.</p>
+                                <a href="{{ path('app_menu') }}" class="btn btn-gold">Voir le menu</a>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="suggestion-card">
+                                <i>📞</i>
+                                <h5>Nous contacter</h5>
+                                <p>Besoin d'aide ? Nous sommes là pour répondre à vos questions.</p>
+                                <a href="{{ path('app_contact') }}" class="btn btn-gold">Contact</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}
+
+

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -1,0 +1,46 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Page non trouvée - Le Trois Quarts | Brasserie Marseille{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    {# Use the same assets as the rest of the site; icons already in base #}
+    <link rel="stylesheet" href="{{ asset('assets/css/404.css') }}?v=7">
+{% endblock %}
+
+{% block body %}
+    <div class="page-404">
+    <section class="error-section">
+                        <div class="container">
+            <div class="row justify-content-center pt-5">
+                <div class="col-lg-8 text-center">
+                    <div class="error-content">
+                        <div class="error-illustration">
+                            <div class="error-number">404</div>
+                            <div class="error-icon">
+                                <i class="bi bi-cup-hot"></i>
+                            </div>
+                        </div>
+
+                        <h1 class="error-title">Oups ! Page non trouvée</h1>
+                        <p class="error-message">
+                            Il semblerait que cette page ait disparu comme un bon plat qui se termine trop vite !
+                            <br>Mais ne vous inquiétez pas, nous avons plein d'autres délices à vous proposer.
+                        </p>
+
+                        <div class="error-actions">
+                            <a href="{{ path('app_home') }}" class="btn btn-gold btn-lg me-3">
+                                <i class="bi bi-house me-2"></i>Retour à l'accueil
+                            </a>
+                            <a href="{{ path('app_menu') }}" class="btn btn-outline-gold btn-lg">
+                                <i class="bi bi-book me-2"></i>Voir le menu
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    </div>
+{% endblock %}
+


### PR DESCRIPTION
…e chrome

- Use base layout to include the same header/footer and global assets

- Load Bootstrap, Bootstrap Icons, and Google Fonts via base layout

- Scope page-specific styles to 404 only (no global overrides)

- Apply light beige background and matching typography

- Create suggestions grid with minimal CTAs: Home and Menu

- Center content vertically

- Ensure navigation links use app_home and app_menu routes