### PR TITLE
feat(order): add Order API and integrate checkout frontend

### DIFF
--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -3,13 +3,14 @@ nelmio_api_doc:
         info:
             title: 'Le Trois Quarts - API'
             description: |
-                🛒 REST API for shopping cart and reviews management
+                🛒 REST API for shopping cart, orders and reviews management
                 
                 ## Features
                 - Storage in PHP session (not localStorage)
                 - Prices always from database (secure)
                 - Synchronization between tabs
                 - 24-hour persistence
+                - Complete order lifecycle management
                 
                 ## Usage
                 All requests require a session cookie.
@@ -26,6 +27,8 @@ nelmio_api_doc:
         tags:
             - name: 'Cart'
               description: 'Shopping cart operations'
+            - name: 'Order'
+              description: 'Order management operations'
             - name: 'Reviews'
               description: 'Customer reviews operations'
     areas:

--- a/src/Controller/OrderController.php
+++ b/src/Controller/OrderController.php
@@ -2,16 +2,290 @@
 
 namespace App\Controller;
 
+use App\DTO\ApiResponseDTO;
+use App\DTO\OrderItemDTO;
+use App\DTO\OrderResponseDTO;
+use App\Service\OrderService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use OpenApi\Attributes as OA;
 
 class OrderController extends AbstractController
 {
+    public function __construct(
+        private OrderService $orderService
+    ) {}
+
     #[Route('/order', name: 'app_order')]
     public function index(): Response
     {
         return $this->render('order/index.html.twig');
+    }
+
+    /**
+     * Create a new order
+     */
+    #[Route('/api/order', name: 'api_order_create', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/order',
+        summary: 'Create order',
+        description: 'Creates a new order from the current cart contents',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(
+                        property: 'deliveryMode', 
+                        type: 'string', 
+                        enum: ['delivery', 'pickup'],
+                        example: 'delivery', 
+                        description: 'Delivery mode'
+                    ),
+                    new OA\Property(
+                        property: 'deliveryAddress', 
+                        type: 'string', 
+                        example: '123 Main St', 
+                        description: 'Delivery address (required if deliveryMode=delivery)'
+                    ),
+                    new OA\Property(
+                        property: 'deliveryZip', 
+                        type: 'string', 
+                        example: '75001', 
+                        description: 'Delivery ZIP code'
+                    ),
+                    new OA\Property(
+                        property: 'deliveryInstructions', 
+                        type: 'string', 
+                        example: 'Ring doorbell', 
+                        description: 'Delivery instructions'
+                    ),
+                    new OA\Property(
+                        property: 'deliveryFee', 
+                        type: 'number',
+                        format: 'float',
+                        example: 5.0, 
+                        description: 'Delivery fee (default: 5.00 for delivery, 0.00 for pickup)'
+                    ),
+                    new OA\Property(
+                        property: 'paymentMode', 
+                        type: 'string',
+                        enum: ['card', 'cash', 'tickets'],
+                        example: 'card', 
+                        description: 'Payment mode'
+                    )
+                ],
+                type: 'object'
+            )
+        ),
+        tags: ['Order']
+    )]
+    #[OA\Response(
+        response: 201,
+        description: 'Order created successfully',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'message', type: 'string', example: 'Commande créée avec succès'),
+                new OA\Property(property: 'order', type: 'object', description: 'Order data')
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: 400,
+        description: 'Invalid data or empty cart',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: false),
+                new OA\Property(property: 'message', type: 'string', example: 'Le panier est vide')
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: 500,
+        description: 'Internal server error',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: false),
+                new OA\Property(property: 'message', type: 'string', example: 'Erreur lors de la création de la commande')
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Tag(name: 'Order')]
+    public function createOrder(Request $request): JsonResponse
+    {
+        try {
+            $data = json_decode($request->getContent(), true);
+            
+            // Créer la commande
+            $order = $this->orderService->createOrder($data ?? []);
+
+            // Convertir les items en DTOs
+            $orderItems = [];
+            foreach ($order->getItems() as $item) {
+                $orderItems[] = new OrderItemDTO(
+                    id: $item->getId(),
+                    productId: $item->getProductId(),
+                    productName: $item->getProductName(),
+                    unitPrice: (float) $item->getUnitPrice(),
+                    quantity: $item->getQuantity(),
+                    total: (float) $item->getTotal()
+                );
+            }
+
+            $orderResponse = new OrderResponseDTO(
+                id: $order->getId(),
+                no: $order->getNo(),
+                status: $order->getStatus()->value,
+                deliveryMode: $order->getDeliveryMode()->value,
+                deliveryAddress: $order->getDeliveryAddress(),
+                deliveryZip: $order->getDeliveryZip(),
+                deliveryInstructions: $order->getDeliveryInstructions(),
+                deliveryFee: (float) $order->getDeliveryFee(),
+                paymentMode: $order->getPaymentMode()->value,
+                subtotal: (float) $order->getSubtotal(),
+                taxAmount: (float) $order->getTaxAmount(),
+                total: (float) $order->getTotal(),
+                createdAt: $order->getCreatedAt()->format(\DateTime::ATOM),
+                items: $orderItems
+            );
+
+            $response = new ApiResponseDTO(
+                success: true,
+                message: 'Commande créée avec succès',
+                order: $orderResponse
+            );
+
+            return $this->json($response->toArray(), 201);
+
+        } catch (\InvalidArgumentException $e) {
+            $response = new ApiResponseDTO(
+                success: false,
+                message: $e->getMessage()
+            );
+            return $this->json($response->toArray(), 400);
+        } catch (\Exception $e) {
+            $response = new ApiResponseDTO(
+                success: false,
+                message: 'Erreur lors de la création de la commande: ' . $e->getMessage()
+            );
+            return $this->json($response->toArray(), 500);
+        }
+    }
+
+    /**
+     * Get order by ID
+     */
+    #[Route('/api/order/{id}', name: 'api_order_get', methods: ['GET'])]
+    #[OA\Get(
+        path: '/api/order/{id}',
+        summary: 'Get order',
+        description: 'Returns order details by order ID',
+        tags: ['Order']
+    )]
+    #[OA\Parameter(
+        name: 'id',
+        in: 'path',
+        required: true,
+        description: 'Order ID',
+        schema: new OA\Schema(type: 'integer', example: 1)
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Successful response',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: true),
+                new OA\Property(property: 'order', type: 'object', description: 'Order data')
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Order not found',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: false),
+                new OA\Property(property: 'message', type: 'string', example: 'Commande introuvable')
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: 500,
+        description: 'Internal server error',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean', example: false),
+                new OA\Property(property: 'message', type: 'string', example: 'Erreur lors de la récupération de la commande')
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Tag(name: 'Order')]
+    public function getOrder(int $id): JsonResponse
+    {
+        try {
+            $order = $this->orderService->getOrder($id);
+            
+            if (!$order) {
+                $response = new ApiResponseDTO(
+                    success: false,
+                    message: 'Commande introuvable'
+                );
+                return $this->json($response->toArray(), 404);
+            }
+
+            // Convertir les items en DTOs
+            $orderItems = [];
+            foreach ($order->getItems() as $item) {
+                $orderItems[] = new OrderItemDTO(
+                    id: $item->getId(),
+                    productId: $item->getProductId(),
+                    productName: $item->getProductName(),
+                    unitPrice: (float) $item->getUnitPrice(),
+                    quantity: $item->getQuantity(),
+                    total: (float) $item->getTotal()
+                );
+            }
+
+            $orderResponse = new OrderResponseDTO(
+                id: $order->getId(),
+                no: $order->getNo(),
+                status: $order->getStatus()->value,
+                deliveryMode: $order->getDeliveryMode()->value,
+                deliveryAddress: $order->getDeliveryAddress(),
+                deliveryZip: $order->getDeliveryZip(),
+                deliveryInstructions: $order->getDeliveryInstructions(),
+                deliveryFee: (float) $order->getDeliveryFee(),
+                paymentMode: $order->getPaymentMode()->value,
+                subtotal: (float) $order->getSubtotal(),
+                taxAmount: (float) $order->getTaxAmount(),
+                total: (float) $order->getTotal(),
+                createdAt: $order->getCreatedAt()->format(\DateTime::ATOM),
+                items: $orderItems
+            );
+
+            $response = new ApiResponseDTO(
+                success: true,
+                order: $orderResponse
+            );
+
+            return $this->json($response->toArray());
+
+        } catch (\Exception $e) {
+            $response = new ApiResponseDTO(
+                success: false,
+                message: 'Erreur lors de la récupération de la commande: ' . $e->getMessage()
+            );
+            return $this->json($response->toArray(), 500);
+        }
     }
 }
 

--- a/src/DTO/ApiResponseDTO.php
+++ b/src/DTO/ApiResponseDTO.php
@@ -21,6 +21,9 @@ class ApiResponseDTO
         #[OA\Property(property: 'cart', type: 'object', description: 'Cart data (when applicable)')]
         public ?CartResponseDTO $cart = null,
 
+        #[OA\Property(property: 'order', type: 'object', description: 'Order data (when applicable)')]
+        public ?OrderResponseDTO $order = null,
+
         #[OA\Property(property: 'count', type: 'integer', example: 3, description: 'Item count (when applicable)')]
         public ?int $count = null
     ) {}
@@ -37,6 +40,10 @@ class ApiResponseDTO
 
         if ($this->cart !== null) {
             $data['cart'] = $this->cart->toArray();
+        }
+
+        if ($this->order !== null) {
+            $data['order'] = $this->order->toArray();
         }
 
         if ($this->count !== null) {

--- a/src/DTO/OrderItemDTO.php
+++ b/src/DTO/OrderItemDTO.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\DTO;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'OrderItem',
+    description: 'Order item representation',
+    type: 'object'
+)]
+class OrderItemDTO
+{
+    public function __construct(
+        #[OA\Property(property: 'id', type: 'integer', example: 1, description: 'Order item ID')]
+        public int $id,
+
+        #[OA\Property(property: 'productId', type: 'integer', example: 5, description: 'Product ID')]
+        public int $productId,
+
+        #[OA\Property(property: 'productName', type: 'string', example: 'Risotto aux champignons', description: 'Product name')]
+        public string $productName,
+
+        #[OA\Property(property: 'unitPrice', type: 'number', format: 'float', example: 14.5, description: 'Unit price')]
+        public float $unitPrice,
+
+        #[OA\Property(property: 'quantity', type: 'integer', example: 2, description: 'Quantity')]
+        public int $quantity,
+
+        #[OA\Property(property: 'total', type: 'number', format: 'float', example: 29.0, description: 'Line total')]
+        public float $total
+    ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'productId' => $this->productId,
+            'productName' => $this->productName,
+            'unitPrice' => $this->unitPrice,
+            'quantity' => $this->quantity,
+            'total' => $this->total
+        ];
+    }
+}
+

--- a/src/DTO/OrderResponseDTO.php
+++ b/src/DTO/OrderResponseDTO.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\DTO;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'OrderResponse',
+    description: 'Order response representation',
+    type: 'object'
+)]
+class OrderResponseDTO
+{
+    public function __construct(
+        #[OA\Property(property: 'id', type: 'integer', example: 1, description: 'Order ID')]
+        public int $id,
+
+        #[OA\Property(property: 'no', type: 'string', example: 'ORD-20250107-001', description: 'Order number')]
+        public string $no,
+
+        #[OA\Property(property: 'status', type: 'string', example: 'pending', description: 'Order status')]
+        public string $status,
+
+        #[OA\Property(property: 'deliveryMode', type: 'string', example: 'delivery', description: 'Delivery mode')]
+        public string $deliveryMode,
+
+        #[OA\Property(property: 'deliveryAddress', type: 'string', example: '123 Main St', description: 'Delivery address', nullable: true)]
+        public ?string $deliveryAddress,
+
+        #[OA\Property(property: 'deliveryZip', type: 'string', example: '75001', description: 'Delivery ZIP code', nullable: true)]
+        public ?string $deliveryZip,
+
+        #[OA\Property(property: 'deliveryInstructions', type: 'string', example: 'Ring doorbell', description: 'Delivery instructions', nullable: true)]
+        public ?string $deliveryInstructions,
+
+        #[OA\Property(property: 'deliveryFee', type: 'number', format: 'float', example: 5.0, description: 'Delivery fee')]
+        public float $deliveryFee,
+
+        #[OA\Property(property: 'paymentMode', type: 'string', example: 'card', description: 'Payment mode')]
+        public string $paymentMode,
+
+        #[OA\Property(property: 'subtotal', type: 'number', format: 'float', example: 29.0, description: 'Subtotal')]
+        public float $subtotal,
+
+        #[OA\Property(property: 'taxAmount', type: 'number', format: 'float', example: 2.9, description: 'Tax amount')]
+        public float $taxAmount,
+
+        #[OA\Property(property: 'total', type: 'number', format: 'float', example: 36.9, description: 'Total amount')]
+        public float $total,
+
+        #[OA\Property(property: 'createdAt', type: 'string', format: 'date-time', example: '2025-01-07T10:30:00+00:00', description: 'Creation date')]
+        public string $createdAt,
+
+        #[OA\Property(property: 'items', type: 'array', items: new OA\Items(type: 'object'), description: 'Order items')]
+        public array $items
+    ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'no' => $this->no,
+            'status' => $this->status,
+            'deliveryMode' => $this->deliveryMode,
+            'deliveryAddress' => $this->deliveryAddress,
+            'deliveryZip' => $this->deliveryZip,
+            'deliveryInstructions' => $this->deliveryInstructions,
+            'deliveryFee' => $this->deliveryFee,
+            'paymentMode' => $this->paymentMode,
+            'subtotal' => $this->subtotal,
+            'taxAmount' => $this->taxAmount,
+            'total' => $this->total,
+            'createdAt' => $this->createdAt,
+            'items' => array_map(fn($item) => $item instanceof OrderItemDTO ? $item->toArray() : $item, $this->items)
+        ];
+    }
+}
+

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -59,7 +59,7 @@ class Order
     /**
      * @var Collection<int, OrderItem>
      */
-    #[ORM\OneToMany(targetEntity: OrderItem::class, mappedBy: 'orderRef', orphanRemoval: true)]
+    #[ORM\OneToMany(targetEntity: OrderItem::class, mappedBy: 'orderRef', orphanRemoval: true, cascade: ['persist'])]
     private Collection $items;
 
     public function __construct()

--- a/src/Entity/OrderItem.php
+++ b/src/Entity/OrderItem.php
@@ -30,7 +30,7 @@ class OrderItem
     #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 2)]
     private ?string $total = null;
 
-    #[ORM\ManyToOne(inversedBy: 'items')]
+    #[ORM\ManyToOne(inversedBy: 'items', cascade: ['persist'])]
     #[ORM\JoinColumn(name: 'order_id', nullable: false, onDelete: 'CASCADE')]
     private ?Order $orderRef = null;
 

--- a/src/Service/OrderService.php
+++ b/src/Service/OrderService.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Order;
+use App\Entity\OrderItem;
+use App\Enum\DeliveryMode;
+use App\Enum\OrderStatus;
+use App\Enum\PaymentMode;
+use App\Repository\OrderRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Service pour gérer les commandes.
+ */
+class OrderService
+{
+    private const TAX_RATE = 0.10; // 10% tax
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private OrderRepository $orderRepository,
+        private CartService $cartService,
+        private RequestStack $requestStack
+    ) {}
+
+    /**
+     * Créer une nouvelle commande à partir du panier
+     */
+    public function createOrder(array $orderData): Order
+    {
+        // Récupérer le panier
+        $cart = $this->cartService->getCart();
+        
+        if (empty($cart['items'])) {
+            throw new \InvalidArgumentException("Le panier est vide");
+        }
+
+        // Créer l'entité Order
+        $order = new Order();
+        $order->setNo($this->generateOrderNumber());
+        $order->setStatus(OrderStatus::PENDING);
+        $order->setCreatedAt(new \DateTimeImmutable());
+
+        // Définir le mode de livraison
+        $deliveryMode = isset($orderData['deliveryMode']) 
+            ? DeliveryMode::from($orderData['deliveryMode'])
+            : DeliveryMode::DELIVERY;
+        $order->setDeliveryMode($deliveryMode);
+
+        // Définir l'adresse de livraison si le mode est delivery
+        if ($deliveryMode === DeliveryMode::DELIVERY) {
+            if (empty($orderData['deliveryAddress'])) {
+                throw new \InvalidArgumentException("L'adresse de livraison est requise");
+            }
+            $order->setDeliveryAddress($orderData['deliveryAddress']);
+            $order->setDeliveryZip($orderData['deliveryZip'] ?? null);
+            $order->setDeliveryInstructions($orderData['deliveryInstructions'] ?? null);
+            $order->setDeliveryFee($orderData['deliveryFee'] ?? '5.00');
+        } else {
+            $order->setDeliveryFee('0.00');
+        }
+
+        // Définir le mode de paiement
+        $paymentMode = isset($orderData['paymentMode']) 
+            ? PaymentMode::from($orderData['paymentMode'])
+            : PaymentMode::CARD;
+        $order->setPaymentMode($paymentMode);
+
+        // Calculer les montants
+        $subtotal = $cart['total'];
+        $taxAmount = round($subtotal * self::TAX_RATE, 2);
+        $deliveryFee = (float) $order->getDeliveryFee();
+        $total = $subtotal + $taxAmount + $deliveryFee;
+
+        $order->setSubtotal((string) $subtotal);
+        $order->setTaxAmount((string) $taxAmount);
+        $order->setTotal((string) $total);
+
+        // Ajouter les items de commande
+        foreach ($cart['items'] as $cartItem) {
+            $orderItem = new OrderItem();
+            $orderItem->setProductId($cartItem['id']);
+            $orderItem->setProductName($cartItem['name']);
+            $orderItem->setUnitPrice((string) $cartItem['price']);
+            $orderItem->setQuantity($cartItem['quantity']);
+            $orderItem->setTotal((string) ($cartItem['price'] * $cartItem['quantity']));
+            $orderItem->setOrderRef($order);
+            
+            $order->addItem($orderItem);
+        }
+
+        // Persister la commande
+        $this->entityManager->persist($order);
+        $this->entityManager->flush();
+
+        // Vider le panier après la création de la commande
+        $this->cartService->clear();
+
+        return $order;
+    }
+
+    /**
+     * Récupérer une commande par ID
+     */
+    public function getOrder(int $orderId): ?Order
+    {
+        return $this->orderRepository->find($orderId);
+    }
+
+    /**
+     * Générer un numéro de commande unique
+     */
+    private function generateOrderNumber(): string
+    {
+        $date = (new \DateTime())->format('Ymd');
+        $random = str_pad((string) random_int(1, 9999), 4, '0', STR_PAD_LEFT);
+        return "ORD-{$date}-{$random}";
+    }
+
+    /**
+     * Mettre à jour le statut d'une commande
+     */
+    public function updateOrderStatus(int $orderId, string $status): Order
+    {
+        $order = $this->getOrder($orderId);
+        
+        if (!$order) {
+            throw new \InvalidArgumentException("Commande introuvable: $orderId");
+        }
+
+        $orderStatus = OrderStatus::from($status);
+        $order->setStatus($orderStatus);
+        
+        $this->entityManager->flush();
+        
+        return $order;
+    }
+}
+


### PR DESCRIPTION
- Add POST /api/order and GET /api/order/{id} endpoints

- Implement OrderService (createOrder/getOrder), 10% tax, order number, cart clear

- Add DTOs (OrderItemDTO, OrderResponseDTO) and extend ApiResponseDTO with order

- Doctrine: cascade persist for Order->items and OrderItem->orderRef

- OpenAPI: add Order tag and annotations; replace invalid  with object types

- Frontend: add window.orderAPI (createOrder/getOrder) and wire confirmOrder()

- Frontend: show order number/total and refresh cart UI after success

- Docs: add/update Order API docs and Nelmio config